### PR TITLE
feat: Implement multi-provider LLM support and refactor

### DIFF
--- a/templates/professional_dashboard.html
+++ b/templates/professional_dashboard.html
@@ -880,6 +880,55 @@
         let isTestRunning = false;
         let coverageChart = null;
 
+        const modelMap = {
+            google: [
+                { value: 'gemini-1.5-flash', text: 'Gemini 1.5 Flash' },
+                { value: 'gemini-1.5-pro', text: 'Gemini 1.5 Pro' }
+            ],
+            openai: [
+                { value: 'gpt-4o', text: 'GPT-4o' },
+                { value: 'gpt-4-turbo', text: 'GPT-4 Turbo' },
+                { value: 'gpt-3.5-turbo', text: 'GPT-3.5 Turbo' }
+            ],
+            groq: [
+                { value: 'llama3-8b-8192', text: 'Llama3 8b' },
+                { value: 'llama3-70b-8192', text: 'Llama3 70b' },
+                { value: 'gemma-7b-it', text: 'Gemma 7b' }
+            ],
+            ollama: [
+                { value: 'llama3', text: 'Llama3' },
+                { value: 'mistral', text: 'Mistral' },
+                { value: 'codellama', text: 'CodeLlama' }
+            ]
+        };
+
+        const apiKeyInfo = {
+            google: {
+                label: 'Google Gemini API Key',
+                placeholder: 'Enter your Google Gemini API key',
+                link: 'https://makersuite.google.com/app/apikey',
+                linkText: 'Google AI Studio'
+            },
+            openai: {
+                label: 'OpenAI API Key',
+                placeholder: 'Enter your OpenAI API key',
+                link: 'https://platform.openai.com/api-keys',
+                linkText: 'OpenAI Platform'
+            },
+            groq: {
+                label: 'Groq API Key',
+                placeholder: 'Enter your Groq API key',
+                link: 'https://console.groq.com/keys',
+                linkText: 'Groq Console'
+            },
+            ollama: {
+                label: 'Ollama (No API Key needed)',
+                placeholder: 'Ollama runs locally, no API key required',
+                link: 'https://ollama.ai',
+                linkText: 'Ollama Website'
+            }
+        };
+
         // Socket.IO event handlers
         socket.on('connect', function() {
             console.log('Connected to server');
@@ -952,8 +1001,23 @@
                 document.getElementById('website_url').value = data.website_url || '';
                 document.getElementById('test_focus').value = data.test_focus || 'about_us';
                 document.getElementById('provider').value = data.provider || 'google';
-                document.getElementById('api_key').value = data.api_key || '';
-                document.getElementById('model').value = data.model || 'gemini-2.5-flash';
+
+                // Update the UI based on the loaded provider
+                updateProviderUI();
+
+                // Load the correct API key
+                const provider = data.provider || 'google';
+                let apiKey = '';
+                if (provider === 'google') {
+                    apiKey = data.google_api_key || '';
+                } else if (provider === 'openai') {
+                    apiKey = data.openai_api_key || '';
+                } else if (provider === 'groq') {
+                    apiKey = data.groq_api_key || '';
+                }
+                document.getElementById('api_key').value = apiKey;
+
+                document.getElementById('model').value = data.model || 'gemini-1.5-flash';
                 document.getElementById('include_functional').checked = data.include_functional !== false;
                 document.getElementById('include_ux_usability').checked = data.include_ux_usability !== false;
                 document.getElementById('include_ui_defects').checked = data.include_ui_defects !== false;
@@ -966,6 +1030,7 @@
                 document.getElementById('custom_prompt').value = data.custom_prompt || '';
                 
                 addLogEntry('Configuration loaded', 'System', 'SUCCESS');
+                updateButtonStates();
             })
             .catch(error => {
                 addLogEntry('Error loading configuration: ' + error, 'Error', 'ERROR');
@@ -974,25 +1039,27 @@
 
         // Test control functions
         function startTest() {
-            // Validate required fields
+            const provider = document.getElementById('provider').value;
             const apiKey = document.getElementById('api_key').value.trim();
-            if (!apiKey) {
-                addLogEntry('❌ Google Gemini API key is required. Please enter your API key in the configuration section.', 'Error', 'ERROR');
-                document.getElementById('api_key').focus();
-                return;
-            }
-
             const websiteUrl = document.getElementById('website_url').value.trim();
+
+            // Validate required fields
             if (!websiteUrl) {
                 addLogEntry('❌ Website URL is required. Please enter a valid URL.', 'Error', 'ERROR');
                 document.getElementById('website_url').focus();
                 return;
             }
 
+            if (provider !== 'ollama' && !apiKey) {
+                addLogEntry(`❌ ${apiKeyInfo[provider].label} is required. Please enter your API key.`, 'Error', 'ERROR');
+                document.getElementById('api_key').focus();
+                return;
+            }
+
             const config = {
                 website_url: websiteUrl,
                 test_focus: document.getElementById('test_focus').value,
-                provider: document.getElementById('provider').value,
+                provider: provider,
                 api_key: apiKey,
                 model: document.getElementById('model').value,
                 include_functional: document.getElementById('include_functional').checked,
@@ -1071,14 +1138,54 @@
             });
         }
 
-        // Add event listeners for input validation
+        function updateProviderUI() {
+            const provider = document.getElementById('provider').value;
+            const modelSelect = document.getElementById('model');
+            const apiKeyLabel = document.querySelector('label[for="api_key"]');
+            const apiKeyInput = document.getElementById('api_key');
+            const apiKeyHelpText = apiKeyInput.nextElementSibling;
+
+            // Update models
+            modelSelect.innerHTML = '';
+            modelMap[provider].forEach(model => {
+                const option = document.createElement('option');
+                option.value = model.value;
+                option.textContent = model.text;
+                modelSelect.appendChild(option);
+            });
+
+            // Update API key field
+            const info = apiKeyInfo[provider];
+            apiKeyLabel.innerHTML = `${info.label}: <span style="color: ${provider === 'ollama' ? 'grey' : 'red'};">*</span>`;
+            apiKeyInput.placeholder = info.placeholder;
+            apiKeyHelpText.innerHTML = `Get your API key from: <a href="${info.link}" target="_blank" style="color: #3b82f6;">${info.linkText}</a>`;
+
+            if (provider === 'ollama') {
+                apiKeyInput.disabled = true;
+                apiKeyInput.parentElement.style.display = 'none';
+            } else {
+                apiKeyInput.disabled = false;
+                apiKeyInput.parentElement.style.display = 'block';
+            }
+            updateButtonStates();
+        }
+
         document.addEventListener('DOMContentLoaded', function() {
-            // Add input event listeners for real-time validation
+            const providerSelect = document.getElementById('provider');
+            providerSelect.addEventListener('change', updateProviderUI);
+
             document.getElementById('api_key').addEventListener('input', updateButtonStates);
             document.getElementById('website_url').addEventListener('input', updateButtonStates);
             
-            // Initial button state update
-            updateButtonStates();
+            // Initial UI setup
+            loadConfiguration();
+            updateProviderUI();
+
+            // Add event listener for enhanced checklist button
+            const checklistBtn = document.getElementById('load_checklist_btn');
+            if (checklistBtn) {
+                checklistBtn.addEventListener('click', loadEnhancedChecklist);
+            }
         });
 
         // Results management
@@ -1277,17 +1384,19 @@
             const startBtn = document.getElementById('startBtn');
             const pauseBtn = document.getElementById('pauseBtn');
             const stopBtn = document.getElementById('stopBtn');
+            const provider = document.getElementById('provider').value;
 
             if (isTestRunning) {
                 startBtn.disabled = true;
                 pauseBtn.disabled = false;
                 stopBtn.disabled = false;
             } else {
-                // Check if configuration is valid
                 const apiKey = document.getElementById('api_key').value.trim();
                 const websiteUrl = document.getElementById('website_url').value.trim();
                 
-                if (apiKey && websiteUrl) {
+                let isConfigValid = websiteUrl && (provider === 'ollama' || apiKey);
+
+                if (isConfigValid) {
                     startBtn.disabled = false;
                     startBtn.title = 'Click to start professional testing';
                 } else {

--- a/test_setup.py
+++ b/test_setup.py
@@ -60,36 +60,22 @@ def test_imports():
     
     return True
 
-def test_environment():
-    """Test environment variables"""
-    print("\n🔍 Testing environment variables...")
+def test_config_files():
+    """Test for the presence of configuration files."""
+    print("\n🔍 Testing for configuration files...")
     
-    # Load .env file if it exists
-    env_file = Path(".env")
-    if env_file.exists():
-        from dotenv import load_dotenv
-        load_dotenv()
-        print("✅ .env file found and loaded")
+    config_file = Path("professional_test_config.json")
+    if config_file.exists():
+        print(f"✅ Found '{config_file}'")
     else:
-        print("⚠️  .env file not found")
-        print("   Please create .env file with your API keys")
-        print("   See env_example.txt for reference")
-    
-    # Check API keys
-    google_key = os.getenv('GOOGLE_API_KEY')
-    laminar_key = os.getenv('LAMINAR_API_KEY')
-    
-    if google_key and google_key != "your_gemini_api_key_here":
-        print("✅ Google API key: SET")
+        print(f"⚠️  '{config_file}' not found. It will be created on first configuration save.")
+
+    results_file = Path("professional_test_results.json")
+    if results_file.exists():
+        print(f"✅ Found '{results_file}'")
     else:
-        print("❌ Google API key: NOT SET")
-        print("   Please set GOOGLE_API_KEY in your .env file")
-    
-    if laminar_key and laminar_key != "your_laminar_api_key_here":
-        print("✅ Laminar API key: SET")
-    else:
-        print("⚠️  Laminar API key: NOT SET (optional)")
-    
+        print(f"⚠️  '{results_file}' not found. It will be created when a test is run.")
+
     return True
 
 def test_file_structure():
@@ -141,7 +127,7 @@ def main():
     
     tests = [
         ("Package Imports", test_imports),
-        ("Environment Variables", test_environment),
+        ("Config Files", test_config_files),
         ("File Structure", test_file_structure),
         ("Browser Automation", test_browser_automation)
     ]

--- a/test_simple.py
+++ b/test_simple.py
@@ -95,35 +95,45 @@ def test_basic_functionality():
     return True
 
 def test_api_key_validation():
-    """Test API key validation logic"""
+    """Test API key validation logic for multiple providers"""
     print("\n🔑 Testing API Key Validation...")
     
     # Test cases
     test_cases = [
-        {"google": "", "laminar": "", "expected": False},
-        {"google": "your_gemini_api_key_here", "laminar": "", "expected": False},
-        {"google": "real_key_123", "laminar": "", "expected": True},
-        {"google": "real_key_123", "laminar": "your_laminar_key_here", "expected": True},
-        {"google": "real_key_123", "laminar": "real_laminar_456", "expected": True},
+        {"provider": "google", "keys": {"google_api_key": ""}, "expected": False},
+        {"provider": "google", "keys": {"google_api_key": "key_123"}, "expected": True},
+        {"provider": "openai", "keys": {"google_api_key": "key_123", "openai_api_key": ""}, "expected": False},
+        {"provider": "openai", "keys": {"openai_api_key": "key_456"}, "expected": True},
+        {"provider": "groq", "keys": {"groq_api_key": "key_789"}, "expected": True},
+        {"provider": "ollama", "keys": {}, "expected": True},  # No key needed
     ]
     
+    all_passed = True
     for i, case in enumerate(test_cases, 1):
-        google_key = case["google"]
-        laminar_key = case["laminar"]
+        provider = case["provider"]
+        keys = case["keys"]
         expected = case["expected"]
         
-        # Simulate the validation logic from the main app
-        is_configured = False
-        if (google_key and google_key != "your_gemini_api_key_here" and 
-            laminar_key and laminar_key != "your_laminar_key_here"):
-            is_configured = True
-        elif google_key and google_key != "your_gemini_api_key_here":
-            is_configured = True
+        # Simulate the validation logic from the main app (start_test)
+        is_valid = False
+        if provider == "ollama":
+            is_valid = True
+        else:
+            api_key_name = f"{provider}_api_key"
+            if keys.get(api_key_name):
+                is_valid = True
         
-        status = "✅" if is_configured == expected else "❌"
-        print(f"{status} Test {i}: Google='{google_key[:10]}...', Laminar='{laminar_key[:10]}...' -> {is_configured} (expected: {expected})")
+        status = "✅" if is_valid == expected else "❌"
+        if is_valid != expected:
+            all_passed = False
+
+        print(f"{status} Test {i}: Provider='{provider}', Keys provided='{list(keys.keys())}' -> Valid={is_valid} (expected: {expected})")
     
-    print("✅ API key validation tests completed")
+    if all_passed:
+        print("✅ All API key validation tests passed")
+    else:
+        print("❌ Some API key validation tests failed")
+
 
 if __name__ == "__main__":
     print("🚀 Gomaa Automation - Simple Test Suite")


### PR DESCRIPTION
This commit introduces support for multiple LLM providers (Google, OpenAI, Groq, Ollama) as suggested by the `browser-use` documentation.

Key changes:
- Added a factory function to create LLM instances for different providers.
- Updated the backend to handle provider-specific API keys.
- Implemented dynamic UI updates in the frontend to allow users to select providers and models. The UI now shows relevant information for each provider.
- Refactored the core testing logic in `ProfessionalTestController` for better readability and maintainability.
- Updated tests to align with the new multi-provider architecture and configuration strategy.
- Fixed an issue where tests would fail due to not using the virtual environment's python interpreter.